### PR TITLE
Add support for iodine (TCP server mode)

### DIFF
--- a/iodine.rb
+++ b/iodine.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'iodine'
+
+class SimpleHTTP
+  def self.on_message client, data
+    client.write "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n"
+    client.close
+  end
+end
+
+APP = Proc.new { SimpleHTTP }
+
+Iodine.listen service: :raw, handler: APP, port: "9090"
+Iodine.threads = -2
+Iodine.workers = 0
+Iodine.start


### PR DESCRIPTION
Hi,

Nice fun benchmark suite.

Iodine is an HTTP/WebSocket server, but it also supports raw TCP/IP communication.

Using iodine's TCP/IP mode (`raw`), I followed your example of implementing a simple HTTP response. This is by far sub-optimal, but it runs.

Feel welcome to add this to the benchmark suite.

Cheers,
   Bo.